### PR TITLE
Serializing & Deserializing DateTime objects

### DIFF
--- a/src/NServiceKit.Text/Common/DateTimeSerializer.cs
+++ b/src/NServiceKit.Text/Common/DateTimeSerializer.cs
@@ -82,9 +82,9 @@ namespace NServiceKit.Text.Common
         /// <returns>The Prepared DateTime.</returns>
         private static DateTime Prepare(this DateTime dateTime, bool parsedAsUtc = false)
         {
-            if (JsConfig.AssumeUtc && dateTime.Kind == DateTimeKind.Unspecified)
+            if (dateTime.Kind == DateTimeKind.Unspecified)
             {
-                dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);    
+                dateTime = DateTime.SpecifyKind(dateTime, JsConfig.AssumeUtc ? DateTimeKind.Utc : DateTimeKind.Local);
             }
 
             if (JsConfig.AlwaysUseUtc)
@@ -163,12 +163,7 @@ namespace NServiceKit.Text.Common
 
             try
             {
-                var parsed = DateTime.Parse(dateTimeStr, null, DateTimeStyles.AssumeLocal);
-                if (JsConfig.AssumeUtc)
-                {
-                    parsed = DateTime.SpecifyKind(parsed, DateTimeKind.Utc);
-                }
-                return parsed.Prepare(parsedAsUtc: JsConfig.AssumeUtc);
+				return DateTime.Parse(dateTimeStr).Prepare();
             }
             catch (FormatException)
             {

--- a/src/NServiceKit.Text/Common/DateTimeSerializer.cs
+++ b/src/NServiceKit.Text/Common/DateTimeSerializer.cs
@@ -82,7 +82,7 @@ namespace NServiceKit.Text.Common
         /// <returns>The Prepared DateTime.</returns>
         private static DateTime Prepare(this DateTime dateTime, bool parsedAsUtc = false)
         {
-            if (dateTime.Kind == DateTimeKind.Unspecified)
+            if (dateTime.Kind == DateTimeKind.Unspecified && JsConfig.DateHandler != JsonDateHandler.TimestampOffset)
             {
                 dateTime = DateTime.SpecifyKind(dateTime, JsConfig.AssumeUtc ? DateTimeKind.Utc : DateTimeKind.Local);
             }

--- a/tests/NServiceKit.Text.Tests/JsonTests/JsonDateTimeTests.cs
+++ b/tests/NServiceKit.Text.Tests/JsonTests/JsonDateTimeTests.cs
@@ -383,7 +383,7 @@ namespace NServiceKit.Text.Tests.JsonTests
             JsConfig.Reset();
         }
 
-        /// <summary>Can deserialize JSON date ISO 8601 without offset as unspecified.</summary>
+        /// <summary>Can deserialize JSON date ISO 8601 without offset as Local (per the ISO 8601 spec).</summary>
         [Test]
         public void Can_deserialize_json_date_iso8601_withoutOffset_asLocal()
         {

--- a/tests/NServiceKit.Text.Tests/JsonTests/JsonDateTimeTests.cs
+++ b/tests/NServiceKit.Text.Tests/JsonTests/JsonDateTimeTests.cs
@@ -385,14 +385,14 @@ namespace NServiceKit.Text.Tests.JsonTests
 
         /// <summary>Can deserialize JSON date ISO 8601 without offset as unspecified.</summary>
         [Test]
-        public void Can_deserialize_json_date_iso8601_withoutOffset_asUnspecified()
+        public void Can_deserialize_json_date_iso8601_withoutOffset_asLocal()
         {
             JsConfig.DateHandler = JsonDateHandler.ISO8601;
 
             const string json = @"""1994-11-24T12:34:56""";
             var fromJson = JsonSerializer.DeserializeFromString<DateTime>(json);
 
-            var dateTime = new DateTime(1994, 11, 24, 12, 34, 56, DateTimeKind.Unspecified);
+            var dateTime = new DateTime(1994, 11, 24, 12, 34, 56, DateTimeKind.Local);
             Assert.That(fromJson, Is.EqualTo(dateTime));
             Assert.That(fromJson.Kind, Is.EqualTo(dateTime.Kind));
             JsConfig.Reset();

--- a/tests/NServiceKit.Text.Tests/NServiceKit.Text.Tests.csproj
+++ b/tests/NServiceKit.Text.Tests/NServiceKit.Text.Tests.csproj
@@ -122,9 +122,6 @@
     <Reference Include="NServiceKit.ServiceInterface">
       <HintPath>..\..\lib\tests\NServiceKit.ServiceInterface.dll</HintPath>
     </Reference>
-    <Reference Include="NServiceKit.Text">
-      <HintPath>..\..\src\NServiceKit.Text\bin\Release\NServiceKit.Text.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
@@ -132,22 +129,9 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
       <HintPath>..\..\lib\tests\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Platform">
-      <HintPath>..\..\lib\tests\Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="protobuf-net">
-      <HintPath>..\..\lib\tests\protobuf-net.dll</HintPath>
-    </Reference>
-    <Reference Include="protobuf-net.Extensions">
-      <HintPath>..\..\lib\tests\protobuf-net.Extensions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -264,6 +248,12 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NServiceKit.Text\NServiceKit.Text.csproj">
+      <Project>{579b3fdb-cdad-44e1-8417-885c38e49a0e}</Project>
+      <Name>NServiceKit.Text</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
+++ b/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
@@ -94,7 +94,7 @@ namespace NServiceKit.Text.Tests.Utils
         }
 
         /// <summary>UTC local equals.</summary>
-		[Test, Ignore]
+		[Test][Ignore]
 		public void Utc_Local_Equals()
 		{
 			var now = DateTime.Now;

--- a/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
+++ b/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
@@ -428,22 +428,18 @@ namespace NServiceKit.Text.Tests.Utils
 			// TEST 1: No JsConfig options set should deserialize as local
 			var deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 			Assert.AreEqual(DateTimeKind.Local, deserialized.Date.Kind);
-		    Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.Now));
 
 			var deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 			Assert.AreEqual(DateTimeKind.Local, deserializedJson.Date.Kind);
-			Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.Now));
 
 			// TEST 2: AssumeUtc shouldn't change anything because the time zone is specified
 		    using (JsConfig.With(assumeUtc: true))
 		    {
 				deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 				Assert.AreEqual(DateTimeKind.Local, deserialized.Date.Kind);
-				Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.Now));
 
 				deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 				Assert.AreEqual(DateTimeKind.Local, deserializedJson.Date.Kind);
-				Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.Now));
 			}
 
 			// TEST 3: AlwaysUseUtc should convert the time to UTC 
@@ -451,13 +447,10 @@ namespace NServiceKit.Text.Tests.Utils
 			{
 				deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 				Assert.AreEqual(DateTimeKind.Utc, deserialized.Date.Kind);
-				Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.UtcNow));
 
 				deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 				Assert.AreEqual(DateTimeKind.Utc, deserializedJson.Date.Kind);
-				Assert.AreEqual(currentTimeZone.GetUtcOffset(deserializedJson), currentTimeZone.GetUtcOffset(DateTime.UtcNow));
 			}
-
 	    }
     }
 }

--- a/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
+++ b/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
@@ -418,5 +418,41 @@ namespace NServiceKit.Text.Tests.Utils
                 Assert.AreEqual(0, deserializedUtc.Hour);
             }
         }
+
+	    [Test]
+	    public void DateTime_Should_Deserialize_Correctly_If_It_Doesnt_Recognize_The_Offset_and_falls_back_to_DateTimeParse()
+	    {
+			const string dateTimeStr = "2015-03-31T16:02:42-04:00";
+			var deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
+			Assert.AreEqual(DateTimeKind.Local, deserialized.Date.Kind);
+			Assert.AreEqual(16, deserialized.Hour);
+
+			var deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
+			Assert.AreEqual(DateTimeKind.Local, deserializedJson.Date.Kind);
+			Assert.AreEqual(16, deserializedJson.Hour);
+
+		    using (JsConfig.With(assumeUtc: true))
+		    {
+				deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
+				Assert.AreEqual(DateTimeKind.Local, deserialized.Date.Kind);
+				Assert.AreEqual(16, deserialized.Hour);
+
+				deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
+				Assert.AreEqual(DateTimeKind.Local, deserializedJson.Date.Kind);
+				Assert.AreEqual(16, deserializedJson.Hour);
+		    }
+
+			using (JsConfig.With(alwaysUseUtc: true))
+			{
+				deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
+				Assert.AreEqual(DateTimeKind.Utc, deserialized.Date.Kind);
+				Assert.AreEqual(20, deserialized.Hour);
+
+				deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
+				Assert.AreEqual(DateTimeKind.Utc, deserializedJson.Date.Kind);
+				Assert.AreEqual(20, deserializedJson.Hour);
+			}
+
+	    }
     }
 }

--- a/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
+++ b/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
@@ -423,34 +423,39 @@ namespace NServiceKit.Text.Tests.Utils
 	    public void DateTime_Should_Deserialize_Correctly_If_It_Doesnt_Recognize_The_Offset_and_falls_back_to_DateTimeParse()
 	    {
 			const string dateTimeStr = "2015-03-31T16:02:42-04:00";
+			var currentTimeZone = TimeZone.CurrentTimeZone;
+
+			// TEST 1: No JsConfig options set should deserialize as local
 			var deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 			Assert.AreEqual(DateTimeKind.Local, deserialized.Date.Kind);
-			Assert.AreEqual(16, deserialized.Hour);
+		    Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.Now));
 
 			var deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 			Assert.AreEqual(DateTimeKind.Local, deserializedJson.Date.Kind);
-			Assert.AreEqual(16, deserializedJson.Hour);
+			Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.Now));
 
+			// TEST 2: AssumeUtc shouldn't change anything because the time zone is specified
 		    using (JsConfig.With(assumeUtc: true))
 		    {
 				deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 				Assert.AreEqual(DateTimeKind.Local, deserialized.Date.Kind);
-				Assert.AreEqual(16, deserialized.Hour);
+				Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.Now));
 
 				deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 				Assert.AreEqual(DateTimeKind.Local, deserializedJson.Date.Kind);
-				Assert.AreEqual(16, deserializedJson.Hour);
-		    }
+				Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.Now));
+			}
 
+			// TEST 3: AlwaysUseUtc should convert the time to UTC 
 			using (JsConfig.With(alwaysUseUtc: true))
 			{
 				deserialized = (TypeSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 				Assert.AreEqual(DateTimeKind.Utc, deserialized.Date.Kind);
-				Assert.AreEqual(20, deserialized.Hour);
+				Assert.AreEqual(currentTimeZone.GetUtcOffset(deserialized), currentTimeZone.GetUtcOffset(DateTime.UtcNow));
 
 				deserializedJson = (JsonSerializer.DeserializeFromString<DateTime>(dateTimeStr));
 				Assert.AreEqual(DateTimeKind.Utc, deserializedJson.Date.Kind);
-				Assert.AreEqual(20, deserializedJson.Hour);
+				Assert.AreEqual(currentTimeZone.GetUtcOffset(deserializedJson), currentTimeZone.GetUtcOffset(DateTime.UtcNow));
 			}
 
 	    }

--- a/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
+++ b/tests/NServiceKit.Text.Tests/Utils/DateTimeSerializerTests.cs
@@ -150,9 +150,8 @@ namespace NServiceKit.Text.Tests.Utils
             Assert.AreEqual(dateWithoutMillisecondsUnspecified, deserialized);
         }
 
-        /// <summary>UTC date time is deserialized as kind UTC.</summary>
-		// [Test, Ignore("Don't pre-serialize into Utc")]
-        [Test]
+		/// <summary>UTC date time is deserialized as kind UTC.</summary>
+		[Test]
 		public void UtcDateTime_Is_Deserialized_As_Kind_Utc()
 		{
 			//Serializing UTC


### PR DESCRIPTION
See details in Issue #2.

I was a little surprised that the JsonSerializer calls both DateTimeSerializer.ParseShortestXsdDateTime to deserialize and DateTimeSerializer.WriteWcfJsonDate to serialize, but TypeSerializer only calls DateTimeSerializer.ParseShortestXsdDateTime. It doesn't call DateTimeSerializer.WriteWcfJsonDate at all.

The unit test I added reflects this.
